### PR TITLE
Minimal reproduction to get Mux getStats() error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@hrgui/chromecast-playground",
       "version": "0.0.0",
       "devDependencies": {
+        "@mux/mux-data-chromecast": "^4.12.2",
         "@playwright/test": "^1.36.1",
         "@types/chromecast-caf-receiver": "^6.0.9",
         "@types/lodash.merge": "^4.6.7",
@@ -407,6 +408,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mux/mux-data-chromecast": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-chromecast/-/mux-data-chromecast-4.12.2.tgz",
+      "integrity": "sha512-fPbLRZgxEdC83Sfmc1Uc+DL3/CH6ITkouQVqF+ths/Om8GwZ2Kb0W4ACxoXAtCoxHlLybGWbgwdGrqF7FVptBA==",
+      "dev": true,
+      "dependencies": {
+        "mux-embed": "4.28.1"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.36.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
@@ -711,6 +721,12 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/mux-embed": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.28.1.tgz",
+      "integrity": "sha512-fDJK0Dn3nSqRkLj5LUyjVmFGJt4cWq0/WFq75eP+PMF1cU3lemgKkBVYkTTzx3TUDTuebW+1LZ80r9OTcSa+wQ==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -1136,6 +1152,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@mux/mux-data-chromecast": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-chromecast/-/mux-data-chromecast-4.12.2.tgz",
+      "integrity": "sha512-fPbLRZgxEdC83Sfmc1Uc+DL3/CH6ITkouQVqF+ths/Om8GwZ2Kb0W4ACxoXAtCoxHlLybGWbgwdGrqF7FVptBA==",
+      "dev": true,
+      "requires": {
+        "mux-embed": "4.28.1"
+      }
+    },
     "@playwright/test": {
       "version": "1.36.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.1.tgz",
@@ -1377,6 +1402,12 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "mux-embed": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.28.1.tgz",
+      "integrity": "sha512-fDJK0Dn3nSqRkLj5LUyjVmFGJt4cWq0/WFq75eP+PMF1cU3lemgKkBVYkTTzx3TUDTuebW+1LZ80r9OTcSa+wQ==",
       "dev": true
     },
     "nanoid": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@mux/mux-data-chromecast": "^4.12.2",
     "@playwright/test": "^1.36.1",
     "@types/chromecast-caf-receiver": "^6.0.9",
     "@types/lodash.merge": "^4.6.7",

--- a/src/media_fetcher.ts
+++ b/src/media_fetcher.ts
@@ -53,7 +53,6 @@ class MediaFetcher {
    */
   static fetchMediaInformationById(id: string) {
     return MediaFetcher.fetchMediaById(id).then((item) => {
-      debugger;
       let mediaInfo = new cast.framework.messages.MediaInformation();
       let metadata = new cast.framework.messages.GenericMediaMetadata();
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare module "@mux/mux-data-chromecast";

--- a/tests/base/events.ts
+++ b/tests/base/events.ts
@@ -50,6 +50,9 @@ export const loadMessage = {
         },
       ],
     },
+    customData: {
+      withAds: true,
+    },
   },
   autoplay: true,
 };


### PR DESCRIPTION
This repo is based off https://github.com/googlecast/CastReceiver, but added some tools to make it easy to rerun without requiring an actual Chromecast device.

This PR/branch demonstrates an issue with `@mux/mux-data-chromecast`. When playing ads, MUX runs into an error `Uncaught TypeError: Cannot read properties of null (reading 'getStats')`. This does not impact reporting in MUX, but this error should be caught gracefully.

## Reproduction
1. Pull down this repo and run `npm install` and `npm start` in one tab.
2. In another tab, `npm run run-scenario -T ./tests/scenarios/bbb.ts`

## Expected
1. The test ad `For Bigger Blazes` should play.
2. Big Buck Bunny should play after.

## Actual
1. The test ad `For Bigger Blazes` plays, but Mux ran into an error:
```
Uncaught TypeError: Cannot read properties of null (reading 'getStats')
    at _.h.Eg (cast_receiver_framework.js:874:36)
    at _.h.getStats (cast_receiver_framework.js:940:64)
    at t4.getStateData (chromecast-mux.js:6:1369)
    at n2.value (chromecast-mux.js:6:60739)
    at n2.<anonymous> (chromecast-mux.js:6:57460)
    at chromecast-mux.js:6:12821
    at Array.forEach (<anonymous>)
    at o2 (chromecast-mux.js:6:12798)
    at n2.value [as oldEmit] (chromecast-mux.js:6:12851)
    at s2.emit (chromecast-mux.js:6:55645)
```

2. Big Buck Bunny should play after.