### PR TITLE
Minimal reproduction for an issue with calling getStats() when listening to cast.framework.events.category.CORE events

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -129,9 +129,6 @@ playerManager.setMessageInterceptor(cast.framework.messages.MessageType.MEDIA_ST
 });
 
 playerManager.addEventListener(cast.framework.events.category.CORE, (playerEvent) => {
-  const context = cast.framework.CastReceiverContext.getInstance();
-  const playerManager = context.getPlayerManager();
-
   try {
     console.log(
       "Call to playerManager.getStats() succeeded",

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,6 +128,21 @@ playerManager.setMessageInterceptor(cast.framework.messages.MessageType.MEDIA_ST
   return status;
 });
 
+playerManager.addEventListener(cast.framework.events.category.CORE, (playerEvent) => {
+  const context = cast.framework.CastReceiverContext.getInstance();
+  const playerManager = context.getPlayerManager();
+
+  try {
+    console.log(
+      "Call to playerManager.getStats() succeeded",
+      playerEvent.type,
+      playerManager.getStats()
+    );
+  } catch (err) {
+    console.error("Call to playerManager.getStats() failed", playerEvent.type, err);
+  }
+});
+
 /*
  * Intercept the LOAD request to load and set the contentUrl.
  */


### PR DESCRIPTION
This repo is based off https://github.com/googlecast/CastReceiver, but added some tools to make it easy to rerun without requiring an actual Chromecast device.

This PR/branch demonstrates an issue with `getStats()`. When calling `getStats()` during BREAK_STARTED, BREAK_CLIP_LOADING

## Reproduction
1. Pull down this repo and run `npm install` and `npm start` in one tab.
2. In another tab, `npm run run-scenario -T ./tests/scenarios/bbb.ts`

## Expected
When calling playerManager.getStats() while listening to cast.framework.events.category.CORE, it should not error.

## Actual
When calling playerManager.getStats() while listening to cast.framework.events.category.CORE, it errors in these events:
- BREAK_STARTED
- BREAK_CLIP_LOADING


